### PR TITLE
Freeze Ubuntu, Minor CI improvements

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,21 +6,22 @@ jobs:
     # Only run on PRs if the source branch is on someone else's repo
     if: "${{ github.event_name != 'pull_request' || github.repository != github.event.pull_request.head.repo.full_name }}"
 
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
 
     steps:
-      - name: Checkout repository
+      - name: Checkout Repository
         uses: actions/checkout@v4
-      - name: Validate Gradle wrapper
-        uses: gradle/actions/wrapper-validation@v4
+        with:
+          persist-credentials: false
+      - name: Set up Gradle
+        uses: gradle/actions/setup-gradle@v4
       - name: Set up JDK 21
         uses: actions/setup-java@v4
         with:
           java-version: '21'
           distribution: 'temurin'
-      - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@v4
-      - name: Execute Gradle build
+          check-latest: true
+      - name: Execute Gradle Build
         run: ./gradlew build test --stacktrace
       - name: Prepare Upload
         run: |
@@ -31,14 +32,14 @@ jobs:
 
           mkdir dedicated/build/upload
           cp dedicated/build/libs/SoulFireDedicated-$projectVersion.jar dedicated/build/upload
-      - name: Upload client Build Artifact
+      - name: Upload Client Build Artifacts
         uses: actions/upload-artifact@v4
         with:
           name: SoulFireCLI
           if-no-files-found: error
           path: |
             client/build/upload/*.jar
-      - name: Upload dedicated Build Artifact
+      - name: Upload Dedicated Build Artifacts
         uses: actions/upload-artifact@v4
         with:
           name: SoulFireDedicated

--- a/.github/workflows/dependency-submission.yml
+++ b/.github/workflows/dependency-submission.yml
@@ -7,22 +7,26 @@ permissions:
 
 jobs:
   dependency-submission:
-    runs-on: ubuntu-latest
+    if: github.repository_owner == 'AlexProgrammerDE'
+    runs-on: ubuntu-22.04
     steps:
-      - name: Checkout sources
+      - name: Checkout Repository
         uses: actions/checkout@v4
-      - name: Validate Gradle wrapper
-        uses: gradle/actions/wrapper-validation@v4
+        with:
+          persist-credentials: false
+      - name: Set up Gradle
+        uses: gradle/actions/setup-gradle@v4
       - name: Set up JDK 21
         uses: actions/setup-java@v4
         with:
           java-version: '21'
           distribution: 'temurin'
+          check-latest: true
       - name: Generate and submit dependency graph
         uses: gradle/actions/dependency-submission@v4
         with:
           build-scan-publish: true
-          build-scan-terms-of-service-url: "https://gradle.com/terms-of-service"
-          build-scan-terms-of-service-agree: "yes"
+          build-scan-terms-of-use-url: "https://gradle.com/terms-of-use"
+          build-scan-terms-of-use-agree: "yes"
         env:
           DEPENDENCY_GRAPH_EXCLUDE_PROJECTS: ':(buildSrc|data\-generator)'

--- a/.github/workflows/docker-deploy.yml
+++ b/.github/workflows/docker-deploy.yml
@@ -3,13 +3,15 @@ on: [ release ]
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
 
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
-      - name: Validate Gradle wrapper
-        uses: gradle/actions/wrapper-validation@v4
+        with:
+          persist-credentials: false
+      - name: Set up Gradle
+        uses: gradle/actions/setup-gradle@v4
       - name: Set version
         id: set-version
         run: |
@@ -29,7 +31,7 @@ jobs:
           driver-opts: |
             image=moby/buildkit:v0.11.6
           platforms: linux/amd64,linux/arm64
-      - name: Build and push
+      - name: Build and Push
         uses: docker/build-push-action@v6
         with:
           context: ./


### PR DESCRIPTION
1. Freezes Ubuntu to 22.04 to avoid possible OS-related problems,
2. Sets `persist-credentials` to false in checkout job to avoid exposing repo to greater risks than imagined,
3. Sets `check-latest` to true in java job so that the latest JDK is always fetched instead of re-using the image's version instead,
4. Drops the validation wrapper job in favor of setup-gradle as the latter already has a built-in validation system implemented,
5. Updates Gradle's terms-of-service texts to become terms-of-use instead,
6. Prevents the dependency submission workflow from running on forked repos as submitting snapshots are disabled there.