### PR TITLE
Support selecting all bots at once with the BotCommand

### DIFF
--- a/server/src/main/java/com/soulfiremc/server/command/BotCommand.java
+++ b/server/src/main/java/com/soulfiremc/server/command/BotCommand.java
@@ -41,13 +41,14 @@ public final class BotCommand {
             .forward(
               dispatcher.getRoot(),
               helpSingleRedirect(
-                "Instead of running a command for all possible bots, run it for a specific list of bots. Use a comma to separate the names",
+                "Instead of running a command for all possible bots, run it for a specific list of bots. Use a comma to separate the names. Use all for using all available bots",
                 c -> {
                   var botNames = Set.of(StringArgumentType.getString(c, "bot_names").split(","));
+                  boolean allCondition = botNames.size() == 1 && botNames.iterator().next().equalsIgnoreCase("all");
                   return c.getSource()
                     .withBotIds(getVisibleBots(c)
                       .stream()
-                      .filter(bot -> botNames.contains(bot.accountName()))
+                      .filter(bot -> allCondition || botNames.contains(bot.accountName()))
                       .map(BotConnection::accountProfileId)
                       .collect(Collectors.toSet()));
                 }


### PR DESCRIPTION
Quick PR not tested, not fully integration (might be worth add the suggestion). Furthermore information on the discord.

## PR Details

- Added ability to use `bot all` command to select all available bots. 